### PR TITLE
Update docker-compose to use latest images

### DIFF
--- a/grafana-puppetserver/docker-compose.yml
+++ b/grafana-puppetserver/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "./conf/storage-schemas.conf:/opt/graphite/conf/storage-schemas.conf:ro"
 
   grafana-puppetserver:
-    image: reidmv/grafana-puppetserver:1.6.0
+    image: reidmv/grafana-puppetserver:latest
     container_name: grafana-puppetserver
     ports:
       - "3000:3000"

--- a/view-in-grafana.sh
+++ b/view-in-grafana.sh
@@ -25,6 +25,8 @@ which docker-compose || { echo "ERROR: docker-compose required. Please install d
 
 trap finish EXIT INT 
 
+echo "Getting the latest images"
+docker-compose pull --ignore-pull-failures >/dev/null 2>&1
 docker-compose up -d
 
 echo -n "Waiting for graphite to be ready..."


### PR DESCRIPTION
Prior to this commit each release of this source repository was linked
to a specific reidmv/grafana-puppetserver docker image. This requires
users to update this reposirory every time a new image is pushed to
dockerhub. To reduce the overhead of having to update this repo for
every instance, we should use the latest image from docker hub instead.

This PR will use the latest images on docker hub when starting the view-in-grafana.sh

Along with this, we should implement an automatic build process for #6.