### PR TITLE
(MAINT) Basic Docker Image Cleanup

### DIFF
--- a/grafana-puppetserver/Dockerfile
+++ b/grafana-puppetserver/Dockerfile
@@ -2,13 +2,19 @@ FROM grafana/grafana
 MAINTAINER Reid Vandewiele <reid@puppet.com>
 
 COPY build/* /grafana-puppet/
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && \
+    apt-get -y install curl && \
+    apt-get -y autoremove && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
 ENTRYPOINT /grafana-puppet/run.sh
 
 LABEL org.label-schema.vendor="Reid Vandewiele" \
       org.label-schema.name="Grafana Puppetserver Dashboard" \
       org.label-schema.description="Grafana running a dashboard to display puppetserver metrics captured using npwalker/pe_metric_curl_cron_jobs" \
-      org.label-schema.version="1.7.0" \
-      org.label-schema.vcs-url="https://github.com/puppetlabs/puppetserver-metrics-viz" \
-      org.label-schema.build-date="2017-05-22" \
+      org.label-schema.version="1.7.1" \
+      org.label-schema.vcs-url="https://github.com/puppetlabs/puppet-metrics-viewer" \
+      org.label-schema.build-date="2017-05-26" \
       org.label-schema.docker.schema-version="1.0"

--- a/grafana-puppetserver/build/dashboard-collection-errors.json
+++ b/grafana-puppetserver/build/dashboard-collection-errors.json
@@ -38,7 +38,16 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "type": "dashboards"
+    }
+  ],
   "refresh": false,
   "rows": [
     {
@@ -422,7 +431,7 @@
     ]
   },
   "time": {
-    "from": "now-14d",
+    "from": "now-30d",
     "to": "now"
   },
   "timepicker": {
@@ -452,5 +461,5 @@
   },
   "timezone": "browser",
   "title": "Metric Collection Errors",
-  "version": 0
+  "version": 7
 }

--- a/grafana-puppetserver/build/dashboard-puppetdb-activemq.json
+++ b/grafana-puppetserver/build/dashboard-puppetdb-activemq.json
@@ -37,7 +37,15 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "type": "dashboards"
+    }
+  ],
   "refresh": false,
   "rows": [
     {
@@ -87,15 +95,15 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(servers.*.puppetdb.amq_metrics.DequeueCount, 'Dequeue')"
+              "target": "alias(servers.$server.puppetdb.select metric, 'Dequeue')"
             },
             {
               "refId": "B",
-              "target": "alias(servers.*.puppetdb.amq_metrics.EnqueueCount, 'Enqueue')"
+              "target": "alias(servers.$server.puppetdb.select metric, 'Enqueue')"
             },
             {
               "refId": "C",
-              "target": "alias(servers.*.puppetdb.amq_metrics.DispatchCount, 'Dispatch')"
+              "target": "alias(servers.$server.puppetdb.select metric, 'Dispatch')"
             }
           ],
           "thresholds": [],
@@ -175,11 +183,11 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(servers.*.puppetdb.amq_metrics.MaxMessageSize, 'Max message size')"
+              "target": "alias(servers.$server.puppetdb.select metric, 'Max message size')"
             },
             {
               "refId": "B",
-              "target": "alias(servers.*.puppetdb.amq_metrics.AverageMessageSize, 'Ave message size')"
+              "target": "alias(servers.$server.puppetdb.select metric, 'Ave message size')"
             }
           ],
           "thresholds": [],
@@ -259,7 +267,8 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(servers.*.puppetdb.amq_metrics.AverageEnqueueTime, 'ave. enqueue time')"
+              "target": "alias(servers.$server.puppetdb.select metric, 'ave. enqueue time')",
+              "textEditor": true
             }
           ],
           "thresholds": [],
@@ -339,11 +348,13 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(servers.*.puppetdb.amq_metrics.MemoryUsageByteCount, 'Mem usage byte count')"
+              "target": "alias(servers.$server.puppetdb.select metric, 'Mem usage byte count')",
+              "textEditor": true
             },
             {
               "refId": "B",
-              "target": "alias(servers.*.puppetdb.amq_metrics.mem.select metric, 'Mem usage byte count')"
+              "target": "alias(servers.$server.puppetdb.amq_metrics.mem.select metric, 'Mem usage byte count')",
+              "textEditor": true
             }
           ],
           "thresholds": [],
@@ -423,11 +434,11 @@
           "targets": [
             {
               "refId": "A",
-              "target": "alias(servers.*.puppetdb.amq_metrics.QueueSize, 'Queue size')"
+              "target": "alias(servers.$server.puppetdb.select metric, 'Queue size')"
             },
             {
               "refId": "B",
-              "target": "alias(servers.*.puppetdb.amq_metrics.QueueSize, 'Queue size')"
+              "target": "alias(servers.$server.puppetdb.select metric, 'Queue size')"
             }
           ],
           "thresholds": [],
@@ -478,11 +489,32 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE-STATSD}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Server",
+        "multi": false,
+        "name": "server",
+        "options": [],
+        "query": "servers.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
-    "from": "2017-05-02T01:45:32.185Z",
-    "to": "2017-05-02T20:58:26.684Z"
+    "from": "now-30d",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -511,5 +543,5 @@
   },
   "timezone": "browser",
   "title": "PuppetDB Activemq",
-  "version": 0
+  "version": 6
 }

--- a/grafana-puppetserver/build/dashboard-puppetdb-performance.json
+++ b/grafana-puppetserver/build/dashboard-puppetdb-performance.json
@@ -40,8 +40,12 @@
   "id": null,
   "links": [
     {
+      "asDropdown": false,
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [],
+      "title": "Linked Dashboards",
       "type": "dashboards"
     }
   ],
@@ -99,7 +103,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.global_processed.FiveMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.global_processed.FiveMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -185,7 +189,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.global_processing-time.FiveMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.global_processing-time.FiveMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -266,7 +270,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.puppetdb-status.status.queue_depth, 1, 5)"
+              "target": "aliasByNode(servers.$server.puppetdb.puppetdb-status.status.queue_depth, 1, 5)"
             }
           ],
           "thresholds": [],
@@ -346,7 +350,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.storage_replace-catalog-time.FiveMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.storage_replace-catalog-time.FiveMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -414,7 +418,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.storage_replace-facts-time.FiveMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.storage_replace-facts-time.FiveMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -482,7 +486,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.storage_store-report-time.FiveMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.storage_store-report-time.FiveMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -533,11 +537,32 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE-STATSD}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Server",
+        "multi": false,
+        "name": "server",
+        "options": [],
+        "query": "servers.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
-    "from": "2017-04-05T18:52:05.866Z",
-    "to": "2017-04-19T18:52:05.866Z"
+    "from": "now-30d",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -566,5 +591,5 @@
   },
   "timezone": "browser",
   "title": "PuppetDB Performance",
-  "version": 1
+  "version": 9
 }

--- a/grafana-puppetserver/build/dashboard-puppetdb-workload.json
+++ b/grafana-puppetserver/build/dashboard-puppetdb-workload.json
@@ -98,7 +98,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.global_message-persistence-time.FiveMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.global_message-persistence-time.FiveMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -178,7 +178,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.PDBReadPool_pool_Usage.50thPercentile, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.PDBReadPool_pool_Usage.50thPercentile, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -246,7 +246,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.PDBReadPool_pool_Wait.FifteenMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.PDBReadPool_pool_Wait.FifteenMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -314,7 +314,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.PDBReadPool_pool_PendingConnections.Value, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.PDBReadPool_pool_PendingConnections.Value, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -394,7 +394,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.PDBWritePool_pool_Usage.50thPercentile, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.PDBWritePool_pool_Usage.50thPercentile, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -462,7 +462,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.PDBWritePool_pool_Wait.FifteenMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.PDBWritePool_pool_Wait.FifteenMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -530,7 +530,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.PDBWritePool_pool_PendingConnections.Value, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.PDBWritePool_pool_PendingConnections.Value, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -610,7 +610,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.global_discarded.FiveMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.global_discarded.FiveMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -678,7 +678,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "aliasByNode(servers.*.puppetdb.global_fatal.FiveMinuteRate, 1, 3)"
+              "target": "aliasByNode(servers.$server.puppetdb.global_fatal.FiveMinuteRate, 1, 3)"
             }
           ],
           "thresholds": [],
@@ -729,10 +729,31 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_GRAPHITE-STATSD}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Server",
+        "multi": false,
+        "name": "server",
+        "options": [],
+        "query": "servers.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-30d",
     "to": "now"
   },
   "timepicker": {
@@ -762,5 +783,5 @@
   },
   "timezone": "browser",
   "title": "PuppetDB Workload",
-  "version": 1
+  "version": 6
 }

--- a/grafana-puppetserver/build/dashboard-puppetserver-performance.json
+++ b/grafana-puppetserver/build/dashboard-puppetserver-performance.json
@@ -37,7 +37,15 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "type": "dashboards"
+    }
+  ],
   "refresh": false,
   "rows": [
     {
@@ -619,7 +627,7 @@
     ]
   },
   "time": {
-    "from": "now-14d",
+    "from": "now-30d",
     "to": "now"
   },
   "timepicker": {
@@ -649,5 +657,5 @@
   },
   "timezone": "browser",
   "title": "Puppetserver Performance",
-  "version": 2
+  "version": 5
 }

--- a/grafana-puppetserver/build/dashboard-puppetserver-workload.json
+++ b/grafana-puppetserver/build/dashboard-puppetserver-workload.json
@@ -37,8 +37,15 @@
   "graphTooltip": 0,
   "hideControls": false,
   "id": null,
-  "links": [],
-  "refresh": false,
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "type": "dashboards"
+    }
+  ],
   "rows": [
     {
       "collapse": false,
@@ -344,7 +351,7 @@
     ]
   },
   "time": {
-    "from": "now-14d",
+    "from": "now-30d",
     "to": "now"
   },
   "timepicker": {
@@ -374,5 +381,5 @@
   },
   "timezone": "browser",
   "title": "Puppetserver Workload",
-  "version": 3
+  "version": 4
 }

--- a/grafana-puppetserver/docker-compose.yml
+++ b/grafana-puppetserver/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     image: hopsoft/graphite-statsd:latest
     container_name: graphite-statsd
     ports:
-      - "8080:80"
       - "2003:2003"
     volumes:
       - "./conf/carbon.conf:/opt/graphite/conf/carbon.conf:ro"


### PR DESCRIPTION
These commits make the docker image 4% smaller in size and standardize the dashboards. This PR sets all dashboards to the last 30 days of data, creates links for all dashboard which include linked time, and adds the `$server` variable to all of the dashboards. 

This PR also removes the requirement of having port 8080 available for the statsd container. 