### PR TITLE
Add automated docker build and push to docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: required
+language: ruby
+
+env:
+  global:
+    - COMMIT=${TRAVIS_COMMIT::8}
+    - REPO=reidmv/grafana-puppetserver
+
+services:
+  - docker
+
+before_install:
+  - docker build -t $REPO:latest grafana-puppetserver
+  - docker tag $REPO:latest $REPO:$(docker inspect --format "{{ index .Config.Labels \"org.label-schema.version\"}}" $REPO)
+  - docker pull hopsoft/graphite-statsd:latest
+
+script:
+  - cd grafana-puppetserver 
+  - docker-compose up -d
+  - ruby -rsocket -e 's=TCPSocket.new("localhost",3000)'
+  - docker-compose down
+
+after_success:
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+      docker push $REPO;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ env:
   global:
     - COMMIT=${TRAVIS_COMMIT::8}
     - REPO=reidmv/grafana-puppetserver
+    - DOCKER_USERNAME=reidmv
+    - secure: "NypkuJrbWD/AhZa+YMJQNgjYXvhcdxZTo+6iQAo+M1klbMxftTE5HnKcRjERoQT+aFg9BRXaC1aMcKMswdojfgGo+v9hAAYfpFyh78fX9+Iuomspwawxx0+co1/xygkGaNbR/DTFbmCzCd/gRb+BB/1+JJhELlBZlzwYa7xQWqSeiBspL4D6PcvEciTKTqpgl+grrtZIf5xc1ylFn/QBO9wmSWejSD9Oyn2l5bgZ8bFm0BaBvUreiG9DNa21TyslzvpgUS86moN9cFlyHNIngm0HY6WUC41IpUDuY1cr5MKj/We7XlkXRZX9AaJnVgu30h3O8A0PEtGaqAIRxhb6e6u0H/odsDZlJ2JhPXKC7c7yNorobaHD0ocT1/EH+cdpuugDVZhx0OKzXN7JcnIwzTtGo6d+fX6BVqnPEIDn3GhBy7lHheWJ9UrhVEqRFXQ791IrmEP+WC7e/V0S+PihT791iRyxSpx48hcCYxYtb6MtZ+fUpzxz7S5ZyOTdHxHNG9Bb8r30o0mKK2xd3c5+uucBzymGGAqA/FSGUcOkhJG49BwRmnvoxCifW0SupoBhO1EEaSDZ/nY5qnzI7EBgXHpTj0kFglWwNgH7UQzDKpBEsaLj4e/fO+8PKSUlqdaGOKFBzgTJGr0F2xJabE/V4kSQxfd5cHtjFQCDla+Ppxg=" # DOCKER_PASSWORD
 
 services:
   - docker


### PR DESCRIPTION
Prior to this PR, we were manually building the docker image and
pushing it to docker hub. This PR leverages travis to build and push
the image and addresses #6.

This very basic config will build the container with the latest and the version tag from the label metadata, do a basic docker compose test and push it to docker hub if on the master branch.

Prior to merging this PR, you will need to add the encrypted variables DOCKER_USERNAME and
DOCKER_PASSWORD for travis and into the .travis.yml. The branch should be writeable.
