### PR TITLE
Remove blanket rescue of Exception

### DIFF
--- a/json2graphite.rb
+++ b/json2graphite.rb
@@ -64,7 +64,7 @@ def parse_file(filename)
         puts(line)
       end
     end
-  rescue Exception => e
+  rescue => e
     STDERR.puts "ERROR: #{filename}: #{e.message}"
   end
 end


### PR DESCRIPTION
Rescuing the top-level Exception class prevents a bad run of the script from
being terminated by Ctrl-C as the rescue eats the Interrupt exception that gets
generated. Rescuing StandardError should suffice to report most errors.