### PR TITLE
Extract longest JRuby borrow time

### DIFF
--- a/json2graphite.rb
+++ b/json2graphite.rb
@@ -278,6 +278,11 @@ def influx_metrics(data, timestamp, parent_key = nil)
                     "metric"
                   when /http-metrics\Z/
                     "route-id"
+                  when /borrowed-instances\Z/
+                    longest_borrow = value.map {|h| h['duration-millis']}.sort.last
+                    tag_set = influx_tag_parser(current_key.split('.'))
+
+                    next "#{tag_set} longest-borrow=#{longest_borrow} #{timestamp.to_i}"
                   else
                     # Skip all other array valued metrics.
                     next


### PR DESCRIPTION
This commit updates the handlers for array-valued metrics to process the
borrowed-instances array returned by Puppet Server's JRuby metrics. The
handler sorts the array and returns the borrow time of the instance that
has been borrowed the longest and reports it as a metric. This allows
JRuby instances that have become "hung" on a request to be identified
as the longest borrow time will keep increasing until the instance is
released.