### PR TITLE
Add Puppet Server metrics for PuppetDB calls

### DIFF
--- a/json2graphite.rb
+++ b/json2graphite.rb
@@ -274,7 +274,7 @@ def influx_metrics(data, timestamp, parent_key = nil)
                     "resource"
                   when /function-metrics\Z/
                     "function"
-                  when /catalog-metrics\Z/
+                  when /catalog-metrics\Z/, /puppetdb-metrics\Z/
                     "metric"
                   when /http-metrics\Z/
                     "route-id"


### PR DESCRIPTION
This commit extends the InfluxDB parser to extract data from the
`puppetdb-metrics` section that was added to Puppet Server in 2018.1.
This section summarizes measurements for the amount of time that
Puppet Server spends waiting for PuppetDB API calls to complete.