### PR TITLE
Update the graphite port in statsd

### DIFF
--- a/grafana-puppetserver/Dockerfile
+++ b/grafana-puppetserver/Dockerfile
@@ -1,6 +1,8 @@
 FROM grafana/grafana
 MAINTAINER Reid Vandewiele <reid@puppet.com>
 
+USER root
+
 COPY build/* /grafana-puppet/
 RUN apt-get update && \
     apt-get -y install curl && \
@@ -8,6 +10,8 @@ RUN apt-get update && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
+
+USER grafana
 
 ENTRYPOINT /grafana-puppet/run.sh
 

--- a/grafana-puppetserver/build/datasource-graphite-statsd.json
+++ b/grafana-puppetserver/build/datasource-graphite-statsd.json
@@ -1,7 +1,7 @@
 {
   "name":"graphite-statsd",
   "type":"graphite",
-  "url":"http://graphite-statsd:80",
+  "url":"http://graphite-statsd:81",
   "access":"proxy",
   "basicAuth":false
 }


### PR DESCRIPTION
Prior to this commit, the newest release of the hopsoft/graphite-statsd
image moves graphite to port 81 instead of port 80. This commit updates
the datasource to reflect the change.

https://github.com/hopsoft/docker-graphite-statsd/pull/99/files was the change, which makes this fail. This is an interim fix, as #24 would eliminate these containers.