### PR TITLE
Disable Grafana Authentication

### DIFF
--- a/influxdb-grafana/docker-compose.yml
+++ b/influxdb-grafana/docker-compose.yml
@@ -21,3 +21,5 @@ services:
       - "3000:3000"
     volumes:
       - "./grafana:/etc/grafana/provisioning"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true


### PR DESCRIPTION
Prior to this commit, the user had to enter the admin user and password
every time the container was launched. In recent grafana containers, the
password also had to be reset on a new deployment, which was
unneccessary. This commit disables password authentication in the
grafana container.