### PR TITLE
Checking for netcat, and ensuring the error messages for checking commands sends to standard error instead of standard output

### DIFF
--- a/view-in-grafana.sh
+++ b/view-in-grafana.sh
@@ -83,8 +83,8 @@ shift $((OPTIND-1))
 # VALIDATION
 [[ ! -d $1 ]] && { echo "ERROR: First argument must be a directory."; usage; exit 1; }
 
-type docker-compose &>/dev/null || {
-  echo "ERROR: docker-compose required. Please install docker-compose."
+type docker-compose >/dev/null 2>&1 || {
+  echo >&2 "ERROR: docker-compose required. Please install docker-compose."
   exit 1
 }
 
@@ -112,6 +112,10 @@ find "$datadir" -type f -ctime -"${RETENTION_DAYS}" -name "*.bz2" -execdir tar j
 find "$datadir" -type f -ctime -"${RETENTION_DAYS}" -name "*.gz" -execdir tar xf "{}" \; 2>/dev/null
 
 echo "Waiting for database to be ready..."
+type nc >/dev/null 2>&1 || {
+  echo >&2 "ERROR: nc required. Please install ncat/netcat."
+  exit 1
+}
 timeout=60
 until nc -zv 127.0.0.1 2003 &>/dev/null || (( timeout <= 0 )); do
   (( timeout-- ))


### PR DESCRIPTION
On most non-mac *nix installs, netcat is not provided by default these days, and the `nc` command may not work.
We should check for this, much as any other non-standard tool the script relies on. I had to symlink nmap's
`ncat` command to `nc`.

Additionally, I'm making sure we adhere to i/o redirection convention when checking for presence of tools.